### PR TITLE
Dune 3.11 no longer supports ctypes 0.1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
-(lang dune 3.0)
-(using ctypes 0.1)
+(lang dune 3.7)
+(using ctypes 0.3)
 (name jansson)
 (generate_opam_files true)
 (source

--- a/jansson.opam
+++ b/jansson.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/patricoferris/ocaml-jansson"
 doc: "https://ocaml.org/p/jansson"
 bug-reports: "https://github.com/patricoferris/ocaml-jansson/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.7"}
   "ctypes"
   "conf-cmake"
   "alcotest" {with-test}


### PR DESCRIPTION
It built and ran tests successfully after this, but I've not tested in beyond that.